### PR TITLE
chore: update legal entity name to iGrant Technologies AB

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2025] [LCubed (iGrant.io), Sweden]
+   Copyright [2025] [iGrant Technologies AB (iGrant.io), Sweden]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2025] [iGrant Technologies AB (iGrant.io), Sweden]
+   Copyright [2026] [iGrant Technologies AB (iGrant.io), Sweden]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The consent BB admin dashboard can now be accessed at [https://privacy.bb-consen
 Feel free to improve the plugin and send us a pull request. If you find any problems, please create an issue in this repo.
 
 ## Licensing
-Copyright (c) 2023-25 LCubed AB (iGrant.io), Sweden
+Copyright (c) 2023-25 iGrant Technologies AB (iGrant.io), Sweden
 
 Licensed under the Apache 2.0 License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The consent BB admin dashboard can now be accessed at [https://privacy.bb-consen
 Feel free to improve the plugin and send us a pull request. If you find any problems, please create an issue in this repo.
 
 ## Licensing
-Copyright (c) 2023-25 iGrant Technologies AB (iGrant.io), Sweden
+Copyright (c) 2026 iGrant Technologies AB (iGrant.io), Sweden
 
 Licensed under the Apache 2.0 License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 

--- a/src/Components/ForgotPassword/ForgotPassword.jsx
+++ b/src/Components/ForgotPassword/ForgotPassword.jsx
@@ -218,7 +218,7 @@ class ForgotPassword extends Component {
         <div className="forgot-password-footer-container">
           <div className="forgot-password-footer">
             <p className="copyright">
-              Copyright © 2023 LCubed AB, Sweden. All rights reserved.
+              Copyright © 2023 iGrant Technologies AB, Sweden. All rights reserved.
             </p>
             <LanguageSelector t={t} />
             <Logo />

--- a/src/Components/ForgotPassword/ForgotPassword.jsx
+++ b/src/Components/ForgotPassword/ForgotPassword.jsx
@@ -218,7 +218,7 @@ class ForgotPassword extends Component {
         <div className="forgot-password-footer-container">
           <div className="forgot-password-footer">
             <p className="copyright">
-              Copyright © 2026 iGrant Technologies AB, Sweden. All rights reserved.
+              Copyright © {new Date().getFullYear()} iGrant Technologies AB, Sweden. All rights reserved.
             </p>
             <LanguageSelector t={t} />
             <Logo />

--- a/src/Components/ForgotPassword/ForgotPassword.jsx
+++ b/src/Components/ForgotPassword/ForgotPassword.jsx
@@ -218,7 +218,7 @@ class ForgotPassword extends Component {
         <div className="forgot-password-footer-container">
           <div className="forgot-password-footer">
             <p className="copyright">
-              Copyright © 2023 iGrant Technologies AB, Sweden. All rights reserved.
+              Copyright © 2026 iGrant Technologies AB, Sweden. All rights reserved.
             </p>
             <LanguageSelector t={t} />
             <Logo />

--- a/src/Components/Login/Login.jsx
+++ b/src/Components/Login/Login.jsx
@@ -255,7 +255,7 @@ class Login extends Component {
           <div className="login-footer-container">
             <div className="login-footer">
               <p className="copyright">
-                Copyright © 2023 iGrant Technologies AB, Sweden. All rights reserved.
+                Copyright © 2026 iGrant Technologies AB, Sweden. All rights reserved.
               </p>
               <LanguageSelector t={t} />
               <Logo />

--- a/src/Components/Login/Login.jsx
+++ b/src/Components/Login/Login.jsx
@@ -255,7 +255,7 @@ class Login extends Component {
           <div className="login-footer-container">
             <div className="login-footer">
               <p className="copyright">
-                Copyright © 2026 iGrant Technologies AB, Sweden. All rights reserved.
+                Copyright © {new Date().getFullYear()} iGrant Technologies AB, Sweden. All rights reserved.
               </p>
               <LanguageSelector t={t} />
               <Logo />

--- a/src/Components/Login/Login.jsx
+++ b/src/Components/Login/Login.jsx
@@ -255,7 +255,7 @@ class Login extends Component {
           <div className="login-footer-container">
             <div className="login-footer">
               <p className="copyright">
-                Copyright © 2023 LCubed AB, Sweden. All rights reserved.
+                Copyright © 2023 iGrant Technologies AB, Sweden. All rights reserved.
               </p>
               <LanguageSelector t={t} />
               <Logo />


### PR DESCRIPTION
Our legal entity name is now **iGrant Technologies AB**, formerly **LCubed AB**.

This PR replaces references to the old legal entity name **LCubed AB** with the new name **iGrant Technologies AB** in licensing/copyright, legal, and current branding text.

Left unchanged: technical identifiers, i18n keys, file names/URLs, and historical records.